### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -81,7 +81,7 @@ class action_plugin_nftr extends DokuWiki_Action_Plugin {
     /**
     * Register its handlers with the DokuWiki's event controller
     */
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         // alter html/http header for meta data
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE',  $this, 'setNoindex');


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
